### PR TITLE
Fixes typo and changes vars to consts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
-'user strict'
-var contentful = require('contentful')
+'use strict'
 
-var SPACE_ID = 'developer_bookshelf'
-var ACCESS_TOKEN = '0b7f6x59a0'
+const contentful = require('contentful')
 
-var client = contentful.createClient({
+const SPACE_ID = 'developer_bookshelf'
+const ACCESS_TOKEN = '0b7f6x59a0'
+
+const client = contentful.createClient({
   // This is the space ID. A space is like a project folder in Contentful terms
   space: SPACE_ID,
   // This is the access token for this space. Normally you get both ID and the token in the Contentful web app
   accessToken: ACCESS_TOKEN
 })
+
 console.log('\x1b[32m Fetching entries ... \x1b[32m')
 client.getEntries()
   .then((response) => {


### PR DESCRIPTION
This PR will change example code to use `const` instead of `var` when defining variables. Typo in `use strict` is fixed as well.
