### PR TITLE
enhancement: update contentful module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Open the _boilerplate-javascript_ directory and update the _index.js_ file with 
 ```js
 var SPACE_ID = '<space_id>'
 var ACCESS_TOKEN = '<access_token>'
+var ENVIRONMENT = '<environment>'
 ```
 
 ### :three: Install dependencies and start it:

--- a/index.js
+++ b/index.js
@@ -6,12 +6,16 @@ const Table = require('cli-table2')
 
 const SPACE_ID = 'developer_bookshelf'
 const ACCESS_TOKEN = '0b7f6x59a0'
+const ENVIRONMENT = 'master'
 
 const client = contentful.createClient({
   // This is the space ID. A space is like a project folder in Contentful terms
   space: SPACE_ID,
   // This is the access token for this space. Normally you get both ID and the token in the Contentful web app
-  accessToken: ACCESS_TOKEN
+  accessToken: ACCESS_TOKEN,
+  // This is the specified envrionment that the accessToken has access to. To create additional environments check out the docs
+  // https://www.contentful.com/developers/docs/references/content-management-api/#/reference/environments/environment-collection/create-an-environment/console/js
+  environment: ENVIRONMENT
 })
 
 console.log(chalk.green.bold('\nWelcome to the Contentful JS Boilerplate\n'))

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "cli-table2": "^0.2.0",
-    "contentful": "^4.3.0"
+    "contentful": "^6.1.1"
   },
   "devDependencies": {
     "nodemon": "^1.11.0"


### PR DESCRIPTION
## Summary

This pull request is to update the `contentful` module. With this update, more configuration for the client can be set. 

## Description

With the update to the module, I've specified the environment in the configuration of the client to be `master`. By default, this is the environment used if not provided. I just wanted to identify two things

- The `environment` can be configured.
- The `environment` can be set based on what envs the `accessToken` has access to.

## Motivation and Context

I have API keys that talk to specific environments, but I didn't know how to set which environment within my client. After downloading the example boilerplate, I set the `environment` key in the cofiguration, but it was still communicating with the `master` environment`. Since the `contentful` module was out-of-date, I decided to update it.